### PR TITLE
Fix comment typo

### DIFF
--- a/config.inc.php
+++ b/config.inc.php
@@ -13,7 +13,7 @@ $configerror = '';
 // Absolute route for the rrd directory
 $rrd_default_path1 = $librenms_base . '/'.'rrd';
 
-// Loaction of drawn maps 
+// Location of drawn maps
 $weathermap_output = $librenms_base . '/'.'output';
 
 $config_loaded = @include_once 'editor-config.php';


### PR DESCRIPTION
## Summary
- fix a typo in `config.inc.php`

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68668e4f61e8832f8910b7bb43644baa