### PR TITLE
Fix documentation typo 'seperated'

### DIFF
--- a/docs/pages/config-reference.html
+++ b/docs/pages/config-reference.html
@@ -326,7 +326,7 @@ NODE sub_node
  <p xmlns="http://www.w3.org/1999/xhtml" xmlns:xi="http://www.w3.org/2001/XInclude">Specifies where to look for the current "throughput" information for this 
  <a href="#NODE_NODE">NODE.</a> You can also specify multiple targets, which will then be added together 
  to make the aggregate result which is then displayed. Specify the targets on one 
- <a href="#NODE_TARGET">TARGET</a> line, seperated with a space. If a targetspec starts with a '-', then 
+ <a href="#NODE_TARGET">TARGET</a> line, separated with a space. If a targetspec starts with a '-', then 
  it's value will be <i>subtracted</i> from the final result instead. </p> 
  <p xmlns="http://www.w3.org/1999/xhtml" xmlns:xi="http://www.w3.org/2001/XInclude">Also, if a targetspec starts with a number, then a *, then it's used a 
  scaling factor on the result. You can do basic maths with this, especially if 
@@ -1230,7 +1230,7 @@ LINK secondlink
  <p xmlns="http://www.w3.org/1999/xhtml" xmlns:xi="http://www.w3.org/2001/XInclude">Specifies where to look for the current throughput information for this <a href="#LINK_LINK">LINK.</a> 
  You can also specify multiple targets, which will then be added together to make 
  the aggregate bandwidth which is then displayed. Specify the targets on one 
- <a href="#LINK_TARGET">TARGET</a> line, seperated with a space. If a targetspec starts with a '-', then 
+ <a href="#LINK_TARGET">TARGET</a> line, separated with a space. If a targetspec starts with a '-', then 
  it's value will be <i>subtracted</i> from the final result instead. </p> 
  <p xmlns="http://www.w3.org/1999/xhtml" xmlns:xi="http://www.w3.org/2001/XInclude">Also, if a targetspec starts with a number, then a *, then it's used a 
  scaling factor on the result. You can do basic maths with this, especially if 

--- a/docs/pages/main.html
+++ b/docs/pages/main.html
@@ -77,7 +77,7 @@
                 device-polling on it's own.</p>
 
                 <p>This particular version is written in PHP, and it can read statistics
-                data from MRTG-produced HTML files, plain tab-seperated text files and
+                data from MRTG-produced HTML files, plain tab-separated text files and
                 from RRD files, such as those produced by newer MRTG setups, Cacti (my
                 favourite) or another tool. It can also generate HTML 'holder' files for
                 the map images, which can include popup overlays of historical data

--- a/docs/pages/targets.html
+++ b/docs/pages/targets.html
@@ -301,7 +301,7 @@
  </div> 
 
  <p>For tab-delimited data files, the format is plain-text, with three 
- tab-seperated columns. The first one is a linkname, and the second and third 
+ tab-separated columns. The first one is a linkname, and the second and third 
  are traffic-in and traffic-out, respectively. The linkname should match the 
  name in the configuration file. This allows you to create one text file for 
  the entire map from some outside source. Traffic in &amp; out values can use 

--- a/docs/src/config-reference.php
+++ b/docs/src/config-reference.php
@@ -282,7 +282,7 @@ NODE sub_node
  <p xmlns="http://www.w3.org/1999/xhtml" xmlns:xi="http://www.w3.org/2001/XInclude">Specifies where to look for the current "throughput" information for this 
  <a href="#NODE_NODE">NODE.</a> You can also specify multiple targets, which will then be added together 
  to make the aggregate result which is then displayed. Specify the targets on one 
- <a href="#NODE_TARGET">TARGET</a> line, seperated with a space. If a targetspec starts with a '-', then 
+ <a href="#NODE_TARGET">TARGET</a> line, separated with a space. If a targetspec starts with a '-', then 
  it's value will be <i>subtracted</i> from the final result instead. </p> 
  <p xmlns="http://www.w3.org/1999/xhtml" xmlns:xi="http://www.w3.org/2001/XInclude">Also, if a targetspec starts with a number, then a *, then it's used a 
  scaling factor on the result. You can do basic maths with this, especially if 
@@ -1186,7 +1186,7 @@ LINK secondlink
  <p xmlns="http://www.w3.org/1999/xhtml" xmlns:xi="http://www.w3.org/2001/XInclude">Specifies where to look for the current throughput information for this <a href="#LINK_LINK">LINK.</a> 
  You can also specify multiple targets, which will then be added together to make 
  the aggregate bandwidth which is then displayed. Specify the targets on one 
- <a href="#LINK_TARGET">TARGET</a> line, seperated with a space. If a targetspec starts with a '-', then 
+ <a href="#LINK_TARGET">TARGET</a> line, separated with a space. If a targetspec starts with a '-', then 
  it's value will be <i>subtracted</i> from the final result instead. </p> 
  <p xmlns="http://www.w3.org/1999/xhtml" xmlns:xi="http://www.w3.org/2001/XInclude">Also, if a targetspec starts with a number, then a *, then it's used a 
  scaling factor on the result. You can do basic maths with this, especially if 

--- a/docs/src/link_target.xml
+++ b/docs/src/link_target.xml
@@ -43,7 +43,7 @@
         <p>Specifies where to look for the current throughput information for this LINK.
         You can also specify multiple targets, which will then be added together to make
         the aggregate bandwidth which is then displayed. Specify the targets on one
-        TARGET line, seperated with a space. If a targetspec starts with a '-', then
+        TARGET line, separated with a space. If a targetspec starts with a '-', then
         it's value will be <i>subtracted</i> from the final result instead.</p>
 
         <p>Also, if a targetspec starts with a number, then a *, then it's used a

--- a/docs/src/link_target.xml.old
+++ b/docs/src/link_target.xml.old
@@ -27,7 +27,7 @@
        this rrd file for the purposes of the input or output value.
        This is mainly useful in combination with the aggregation feature.</p>
        
-       <p>For tab-delimited data files, the format is plain-text, with three tab-seperated columns.
+       <p>For tab-delimited data files, the format is plain-text, with three tab-separated columns.
        The first one is a linkname, and the second and third are traffic-in and traffic-out, respectively.
        The linkname should match the name in the configuration file. This allows you to create one text file
        for the entire map from some outside source. Traffic in &amp; out values can use the same "K,M,G,T" abbreviated forms
@@ -35,7 +35,7 @@
        recognised as a tab-delimited file by Weathermap.</p>
 
 <p>You can also specify multiple targets, which will then be added together to make the aggregate bandwidth
-which is then displayed. Specify the targets on one TARGET line, seperated with a space.</p>
+which is then displayed. Specify the targets on one TARGET line, separated with a space.</p>
 
     </description>
     <changes>

--- a/docs/src/main.php
+++ b/docs/src/main.php
@@ -39,7 +39,7 @@
                 device-polling on it's own.</p>
 
                 <p>This particular version is written in PHP, and it can read statistics
-                data from MRTG-produced HTML files, plain tab-seperated text files and
+                data from MRTG-produced HTML files, plain tab-separated text files and
                 from RRD files, such as those produced by newer MRTG setups, Cacti (my
                 favourite) or another tool. It can also generate HTML 'holder' files for
                 the map images, which can include popup overlays of historical data

--- a/docs/src/node_target.xml
+++ b/docs/src/node_target.xml
@@ -42,7 +42,7 @@
         <p>Specifies where to look for the current "throughput" information for this
         NODE. You can also specify multiple targets, which will then be added together
         to make the aggregate result which is then displayed. Specify the targets on one
-        TARGET line, seperated with a space. If a targetspec starts with a '-', then
+        TARGET line, separated with a space. If a targetspec starts with a '-', then
         it's value will be <i>subtracted</i> from the final result instead.</p>
 
         <p>Also, if a targetspec starts with a number, then a *, then it's used a

--- a/docs/src/targets.php
+++ b/docs/src/targets.php
@@ -262,7 +262,7 @@ include "common-page-head.php";
     </div>
 
     <p>For tab-delimited data files, the format is plain-text, with three
-        tab-seperated columns. The first one is a linkname, and the second and third
+        tab-separated columns. The first one is a linkname, and the second and third
         are traffic-in and traffic-out, respectively. The linkname should match the
         name in the configuration file. This allows you to create one text file for
         the entire map from some outside source. Traffic in &amp; out values can use


### PR DESCRIPTION
## Summary
- fix 'seperated' typos in source docs
- update generated HTML pages to match

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68668e8b4574832f963fb6bfbd72742c